### PR TITLE
Update chef-dk-0.3.5.ebuild

### DIFF
--- a/app-admin/chef-dk/chef-dk-0.3.5.ebuild
+++ b/app-admin/chef-dk/chef-dk-0.3.5.ebuild
@@ -23,7 +23,7 @@ src_unpack() {
 }
 
 src_install() {
-  local dest="${D}/opt"
+  local dest="/opt"
   mkdir -p "$dest"
 
   cp -pR ./opt/* "$dest"


### PR DESCRIPTION
At current iteration, this results in a post installation message of:
- You should add /var/tmp/portage/app-admin/chef-dk-0.4.0/image//opt/chefdk/bin to your PATH.
  where the path of /var/tmp/portage will vary based on one's configuragion of portage.  While I do believe that prefixes and build locations could be customized in portage to provide a customized path, this at least will give an accurate message in most cases.
